### PR TITLE
README.md: corrected the parsers YAML configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To enable dialogflow `parsers.dialogflow.access-token` must be set in your `conf
 **Example**
 ```yaml
 parsers:
-  dialogflow:
+  - name: dialogflow
     access-token: "my_apiai_access_key"
 ```
 


### PR DESCRIPTION
Parser error if on using:

```
parsers:
  dialogflow:
    access-token: "my_apiai_access_key"
```

```
Traceback (most recent call last):
  File "/usr/local/bin/opsdroid", line 11, in <module>
    load_entry_point('opsdroid==0+unknown', 'console_scripts', 'opsdroid')()
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/opsdroid/__main__.py", line 196, in main
    opsdroid.load()
  File "/usr/local/lib/python3.6/site-packages/opsdroid/core.py", line 152, in load
    self.train_parsers(self.modules["skills"])
  File "/usr/local/lib/python3.6/site-packages/opsdroid/core.py", line 261, in train_parsers
    rasanlu = [p for p in parsers if p["name"] == "rasanlu"]
  File "/usr/local/lib/python3.6/site-packages/opsdroid/core.py", line 261, in <listcomp>
    rasanlu = [p for p in parsers if p["name"] == "rasanlu"]
TypeError: string indices must be integers
```